### PR TITLE
Fix Markdown plain text list regex

### DIFF
--- a/index.html
+++ b/index.html
@@ -1515,7 +1515,7 @@
                                         .replace(/`(.*?)`/gim,'$1')    
                                         .replace(/\[(.*?)\]\((.*?)\)/gim,'$1 ($2)') 
                                         .replace(/^\s*[-*+] (.*)/gim,'- $1') 
-                                        .replace(/^\s*\d+\. (.*)/gim,'$1. $2')
+                                        .replace(/^\s*(\d+)\. (.*)/gim,'$1. $2')
                                         .replace(/<br\s*\/?>/gi, '\n');
                     const dpt=document.createElement('div'); dpt.innerHTML=htmlTmpForPlain; result=(dpt.textContent||dpt.innerText||"").replace(/\n\n+/g, '\n\n').trim(); 
                     break;


### PR DESCRIPTION
## Summary
- fix regex for ordered list conversion in markdownToPlainText

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6859891bb4548325b4b44c24285e913c